### PR TITLE
Set aliases of flags and commands

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -11,8 +11,9 @@ import (
 
 func NewCopyCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "copy",
-		Short: "Copy main program to clipboard",
+		Use:     "copy",
+		Aliases: []string{"c"},
+		Short:   "Copy main program to clipboard",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fname, err := getProgName()
 			if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,12 +9,14 @@ import (
 
 func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize workspace for the contest",
+		Use:     "init",
+		Aliases: []string{"i"},
+		Short:   "Initialize workspace for the contest",
 	}
 
 	atcoder := &cobra.Command{
-		Use:     "at [contest_id]",
+		Use:     "atcoder [contest_id]",
+		Aliases: []string{"at", "a"},
 		Example: "at abc123",
 		Short:   "Initialize workspace for AtCoder",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "",
 		fmt.Sprintf("config file (default %v)", config.DefaultCfg()))
 
 	rootCmd.AddCommand(NewVersionCmd())

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -17,8 +17,9 @@ type sampleCmd struct {
 func NewSampleCmd() *cobra.Command {
 	sample := sampleCmd{}
 	cmd := &cobra.Command{
-		Use:   "sample",
-		Short: "Create sample files",
+		Use:     "sample",
+		Aliases: []string{"p"},
+		Short:   "Create sample files",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return sample.run(cmd, args)
 		},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,8 +8,9 @@ import (
 
 func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "Show this command version",
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "Show this command version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("%v -- %v\n", gitRepo, version)
 		},


### PR DESCRIPTION
Set aliases to reduce types because command names are too long.